### PR TITLE
Feature/ws 624

### DIFF
--- a/awesome_sso/service/depends.py
+++ b/awesome_sso/service/depends.py
@@ -56,7 +56,7 @@ def sso_user_email(payload: dict = Depends(sso_token_decode)) -> EmailStr:
 
 async def sso_user(user_email: EmailStr = Depends(sso_user_email)) -> AwesomeUserType:
     user = await Settings[AwesomeUserType]().user_model.find_one(
-        Settings[AwesomeUserType]().user_model.email == user_email
+        Settings[AwesomeUserType]().user_model.email == user_email, fetch_links=True
     )
     if user is None:
         raise NotFound("user not found")
@@ -97,7 +97,7 @@ async def get_current_user(
     sso_id: PydanticObjectId = Depends(sso_user_id),
 ) -> AwesomeUserType:
     user = await Settings[AwesomeUserType]().user_model.find_one(
-        Settings[AwesomeUserType]().user_model.sso_user_id == sso_id
+        Settings[AwesomeUserType]().user_model.sso_user_id == sso_id, fetch_links=True
     )
     if user is None:
         raise NotFound("user not found")

--- a/awesome_sso/service/route.py
+++ b/awesome_sso/service/route.py
@@ -4,13 +4,7 @@ from fastapi import APIRouter, Depends, Response
 from fastapi.logger import logger
 
 from awesome_sso.exceptions import BadRequest, HTTPException, InternalServerError
-from awesome_sso.service.depends import (
-    JWTPayload,
-    sso_registration,
-    sso_token_decode,
-    sso_user,
-    sso_user_email,
-)
+from awesome_sso.service.depends import sso_registration, sso_user, sso_user_email
 from awesome_sso.service.settings import Settings
 from awesome_sso.service.user.schema import AccessToken, AwesomeUserType, RegisterModel
 from awesome_sso.util.jwt import SYMMETRIC_ALGORITHM, create_token

--- a/awesome_sso/service/user/schema.py
+++ b/awesome_sso/service/user/schema.py
@@ -69,9 +69,13 @@ class AwesomeUser(Document):
     async def register(
         cls: Type[AwesomeUserType], args: RegisterModel
     ) -> AwesomeUserType:
-        return await cls(
-            name=args.name, email=args.email, sso_user_id=args.sso_user_id
-        ).create()
+        return await cls(**args.dict(), **cls.extra_constructor_params(args)).create()
+
+    @classmethod
+    def extra_constructor_params(
+        cls: Type[AwesomeUserType], args: RegisterModel
+    ) -> dict:
+        return {}
 
     async def delete_data(self):
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "awesome-sso"
-version = "0.2.4"
+version = "0.2.5"
 license = "Apache-2.0"
 readme = "README.md"
 description = "sso general utility for services connected to sso"

--- a/tests/service/model.py
+++ b/tests/service/model.py
@@ -1,5 +1,19 @@
+from pydantic import BaseModel
+
 from awesome_sso.service.user.schema import AwesomeUser
 
 
 class FantasticUser(AwesomeUser):
     fantastic: bool = True
+
+
+class ExtraParameter(BaseModel):
+    nickname: str
+
+
+class UserWithExtraParameter(AwesomeUser):
+    extra: ExtraParameter
+
+    @classmethod
+    def extra_constructor_params(cls, args) -> dict:
+        return {"extra": ExtraParameter(nickname=args.name)}

--- a/tests/service/test_user.py
+++ b/tests/service/test_user.py
@@ -2,7 +2,7 @@ import pytest
 
 from awesome_sso.service.user.schema import AwesomeUser
 from tests.conftest import init_mongo
-from tests.service.model import FantasticUser
+from tests.service.model import FantasticUser, UserWithExtraParameter
 
 
 @pytest.fixture(autouse=True)
@@ -25,3 +25,10 @@ async def test_child_user(register_model):
     assert user.sso_user_id == register_model.sso_user_id
     assert user.dict()['fantastic']
 
+
+async def test_child_user_with_extra_param(register_model):
+    user: UserWithExtraParameter = await UserWithExtraParameter.register(register_model)
+    assert user.name == register_model.name
+    assert user.email == register_model.email
+    assert user.sso_user_id == register_model.sso_user_id
+    assert user.extra.nickname == register_model.name


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Added ability for extended child user to use its own field without default value. This is critical is child user has a required field (non-optional field) without default value.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Ran `poe format`, passed `poe lint` and `poe test`?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
