### PR TITLE
make extra_constructor_params async

### DIFF
--- a/awesome_sso/service/user/schema.py
+++ b/awesome_sso/service/user/schema.py
@@ -69,10 +69,11 @@ class AwesomeUser(Document):
     async def register(
         cls: Type[AwesomeUserType], args: RegisterModel
     ) -> AwesomeUserType:
-        return await cls(**args.dict(), **cls.extra_constructor_params(args)).create()
+        extra_params = await cls.extra_constructor_params(args)
+        return await cls(**args.dict(), **extra_params).create()
 
     @classmethod
-    def extra_constructor_params(
+    async def extra_constructor_params(
         cls: Type[AwesomeUserType], args: RegisterModel
     ) -> dict:
         return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "awesome-sso"
-version = "0.2.5"
+version = "0.2.6"
 license = "Apache-2.0"
 readme = "README.md"
 description = "sso general utility for services connected to sso"

--- a/tests/service/model.py
+++ b/tests/service/model.py
@@ -15,5 +15,5 @@ class UserWithExtraParameter(AwesomeUser):
     extra: ExtraParameter
 
     @classmethod
-    def extra_constructor_params(cls, args) -> dict:
+    async def extra_constructor_params(cls, args) -> dict:
         return {"extra": ExtraParameter(nickname=args.name)}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

extra_constructor_params should be async to support async operation while initializing user

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Ran `poe format`, passed `poe lint` and `poe test`?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
