### PR TITLE
get sso user via sso_user_id instead of email

### DIFF
--- a/awesome_sso/service/depends.py
+++ b/awesome_sso/service/depends.py
@@ -6,7 +6,7 @@ from beanie import PydanticObjectId
 from fastapi import Cookie, Depends, Security
 from fastapi.logger import logger
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel
 
 from awesome_sso.exceptions import BadRequest, NotFound, Unauthorized
 from awesome_sso.service.settings import Settings
@@ -51,7 +51,7 @@ def get_sso_user_id(payload: dict = Depends(sso_token_decode)) -> PydanticObject
     if "sso_user_id" not in payload:
         logger.warning(payload)
         raise BadRequest("sso id not found")
-    return payload["sso_user_id"]
+    return PydanticObjectId(payload["sso_user_id"])
 
 
 async def sso_user(

--- a/awesome_sso/service/depends.py
+++ b/awesome_sso/service/depends.py
@@ -22,7 +22,7 @@ class JWTPayload(BaseModel):
 
 
 async def sso_token_decode(
-    credentials: HTTPAuthorizationCredentials = Security(security),
+        credentials: HTTPAuthorizationCredentials = Security(security),
 ) -> dict:
     try:
         jwt_token = credentials.credentials
@@ -37,7 +37,7 @@ async def sso_token_decode(
 
 
 async def sso_registration(
-    register_model: RegisterModel, payload: dict = Depends(sso_token_decode)
+        register_model: RegisterModel, payload: dict = Depends(sso_token_decode)
 ) -> RegisterModel:
     payload["sso_user_id"] = PydanticObjectId(payload["sso_user_id"])
     if payload != register_model.dict():
@@ -47,16 +47,19 @@ async def sso_registration(
     return RegisterModel(**payload)
 
 
-def sso_user_email(payload: dict = Depends(sso_token_decode)) -> EmailStr:
-    if "email" not in payload:
+def get_sso_user_id(payload: dict = Depends(sso_token_decode)) -> PydanticObjectId:
+    if "sso_user_id" not in payload:
         logger.warning(payload)
-        raise BadRequest("email not found")
-    return payload["email"]
+        raise BadRequest("sso id not found")
+    return payload["sso_user_id"]
 
 
-async def sso_user(user_email: EmailStr = Depends(sso_user_email)) -> AwesomeUserType:
+async def sso_user(
+        user_sso_user_id: PydanticObjectId = Depends(get_sso_user_id),
+) -> AwesomeUserType:
     user = await Settings[AwesomeUserType]().user_model.find_one(
-        Settings[AwesomeUserType]().user_model.email == user_email, fetch_links=True
+        Settings[AwesomeUserType]().user_model.sso_user_id == user_sso_user_id,
+        fetch_links=True,
     )
     if user is None:
         raise NotFound("user not found")
@@ -84,8 +87,9 @@ async def jwt_token_decode(eightpoint: str = Cookie(None)) -> JWTPayload:
     return jwt_payload
 
 
+# get from eightpoint cookies
 def sso_user_id(
-    payload: JWTPayload = Depends(jwt_token_decode),
+        payload: JWTPayload = Depends(jwt_token_decode),
 ) -> PydanticObjectId:
     if payload.sso_user_id is None:
         logger.warning(payload)
@@ -94,7 +98,7 @@ def sso_user_id(
 
 
 async def get_current_user(
-    sso_id: PydanticObjectId = Depends(sso_user_id),
+        sso_id: PydanticObjectId = Depends(sso_user_id),
 ) -> AwesomeUserType:
     user = await Settings[AwesomeUserType]().user_model.find_one(
         Settings[AwesomeUserType]().user_model.sso_user_id == sso_id, fetch_links=True

--- a/awesome_sso/service/route.py
+++ b/awesome_sso/service/route.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Response
 from fastapi.logger import logger
 
 from awesome_sso.exceptions import BadRequest, HTTPException, InternalServerError
-from awesome_sso.service.depends import sso_registration, sso_user, sso_user_email
+from awesome_sso.service.depends import get_sso_user_id, sso_registration, sso_user
 from awesome_sso.service.settings import Settings
 from awesome_sso.service.user.schema import AccessToken, AwesomeUserType, RegisterModel
 from awesome_sso.util.jwt import SYMMETRIC_ALGORITHM, create_token
@@ -50,9 +50,9 @@ async def login(user: AwesomeUserType = Depends(sso_user)):
 
 
 @router.post("/unregister")
-async def unregister(email: str = Depends(sso_user_email)):
+async def unregister(sso_user_id: str = Depends(get_sso_user_id)):
     user = await Settings[AwesomeUserType]().user_model.find_one(  # type: ignore
-        Settings[AwesomeUserType]().user_model.email == email  # type: ignore
+        Settings[AwesomeUserType]().user_model.sso_user_id == sso_user_id  # type: ignore
     )
     if user is None:
         return Response(status_code=200, content="requested user not exist")

--- a/awesome_sso/service/user/sync_user.py
+++ b/awesome_sso/service/user/sync_user.py
@@ -18,7 +18,7 @@ async def sync_user(user: AwesomeUserType):
     sso_user = resp.json()
     user.email = sso_user["email"]
     user.name = sso_user["name"]
-    user.line_linked = sso_user['line_linked']
+    user.line_linked = sso_user["line_linked"]
     services = sso_user["services"]
     services_info = []
     config_values = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "awesome-sso"
-version = "0.2.14"
+version = "0.2.15-rc2"
 license = "Apache-2.0"
 readme = "README.md"
 description = "sso general utility for services connected to sso"

--- a/tests/service/test_depends.py
+++ b/tests/service/test_depends.py
@@ -8,7 +8,7 @@ from awesome_sso.service.depends import (
     get_current_user,
     jwt_token_decode,
     sso_user,
-    sso_user_email,
+    get_sso_user_id,
     sso_user_id,
 )
 from awesome_sso.service.settings import Settings
@@ -45,15 +45,15 @@ async def registered_user(register_model: RegisterModel) -> AwesomeUser:
     return user
 
 
-def test_sso_user_email(register_model: RegisterModel):
-    email = sso_user_email(register_model.dict())
-    assert email == register_model.email
+def test_get_sso_user_id(register_model: RegisterModel):
+    sso_id = get_sso_user_id(register_model.dict())
+    assert sso_id == register_model.sso_user_id
     with pytest.raises(BadRequest):
-        sso_user_email({})
+        get_sso_user_id({})
 
 
 async def test_sso_user(registered_user: AwesomeUser, register_model: RegisterModel):
-    test_user = await sso_user(register_model.email)
+    test_user = await sso_user(register_model.sso_user_id)
     assert registered_user.id == test_user.id
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description
update depends `sso_user_email` to `get_sso_user_id`.
because email can be updated by admin-panel, it will cause user  login service failed.
<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Ran `poe format`, passed `poe lint` and `poe test`?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
